### PR TITLE
Fix for typo in indicator type

### DIFF
--- a/malconfminer/node.py
+++ b/malconfminer/node.py
@@ -81,7 +81,7 @@ class Miner(BasePollerFT):
                 else:
                     indicator = domain
                     value = {
-                        'type': 'Domain',
+                        'type': 'domain',
                         'confidence': 80,
                         'IP': ip,
                         'Domain': domain,


### PR DESCRIPTION
Indicator type for domains should be _domain_

(Thanks for this extension, really useful !)

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>