### PR TITLE
Fixes typo in indicator type

### DIFF
--- a/malconfminer/node.py
+++ b/malconfminer/node.py
@@ -63,7 +63,7 @@ class Miner(BasePollerFT):
             if ip is not 'None':
                 indicator = ip
                 value = {
-                    'type': 'IP',
+                    'type': 'IPv4',
                     'confidence': 50,
                     'IP': ip,
                     'Domain': domain,
@@ -81,7 +81,7 @@ class Miner(BasePollerFT):
                 else:
                     indicator = domain
                     value = {
-                        'type': 'Domain',
+                        'type': 'domain',
                         'confidence': 80,
                         'IP': ip,
                         'Domain': domain,


### PR DESCRIPTION
Indicator types for IPs should be _IPv4_ (or IPv6) and for domain should _domain_.

(Thanks for the extension !)

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>